### PR TITLE
switch to new image registry

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   IMAGE_BASE_REGISTRY: quay.io
-  IMAGE_REGISTRY: quay.io/redhat-saia/quarkus-routing-service
+  IMAGE_REGISTRY: quay.io/redhat-composer-ai/conductor
 
 jobs:
   build-jar:
@@ -61,8 +61,8 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
           registry: ${{ env.IMAGE_BASE_REGISTRY }}
 
       - name: Build and push

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Quarkus Service that allows for the routing to different RAG sources and LLMs.
 
+[![Build Image](https://github.com/redhat-composer-ai/quarkus-llm-router/actions/workflows/build-and-push.yaml/badge.svg)](https://github.com/redhat-composer-ai/quarkus-llm-router/actions/workflows/build-and-push.yaml)
+
+[![GitHub](https://img.shields.io/badge/GitHub-repo-blue.svg)](https://github.com/redhat-composer-ai/quarkus-llm-router) [![Quay.io](https://img.shields.io/badge/Quay.io-image-blue.svg)](https://quay.io/repository/redhat-composer-ai/conductor)
+
 ## Architecture
 
 ![](.assets/Routing%20Service.drawio.png)


### PR DESCRIPTION
Updating to a new image registry:

https://quay.io/repository/redhat-composer-ai/conductor

@Jaland You should have gotten an invite for the new registry.

Also, I liked the conductor name for the backend so I figured it would be good to use that as the image registry name.  I think if you like that, we should consider renaming this repo to be `conductor` as well.