### PR TITLE
Making the vector store selection configurable

### DIFF
--- a/src/main/java/com/redhat/composer/config/llm/models/streaming/OpenAiStreamingModel.java
+++ b/src/main/java/com/redhat/composer/config/llm/models/streaming/OpenAiStreamingModel.java
@@ -17,7 +17,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class OpenAiStreamingModel extends StreamingBaseModel {
 
-  Logger log = Logger.getLogger(WeaviateContentRetrieverClient.class);
+  Logger log = Logger.getLogger(OpenAiStreamingModel.class);
 
   @ConfigProperty(name = "openai.default.url")
   private String mistralDefaultUrl;
@@ -41,7 +41,7 @@ public class OpenAiStreamingModel extends StreamingBaseModel {
    */
   public StreamingChatLanguageModel getChatModel(LLMRequest request) {
 
-    log.info("Attempting to create OpenAI Streaming Chat Model at: " + request.getUrl() 
+    log.info("Attempting to create OpenAI Streaming Chat Model at: " + request.getUrl()
                                       + " with model name: " + request.getModelName());
 
     OpenAiStreamingChatModelBuilder builder = OpenAiStreamingChatModel.builder();
@@ -54,8 +54,8 @@ public class OpenAiStreamingModel extends StreamingBaseModel {
     builder.temperature(openaiDefaultTemp);
 
     builder.maxTokens(openaiDefaultMaxTokens);
-    
-    
+
+
     // TODO: Fill all this out
     // if (modelName != null) {
     //   builder.modelName(modelName);
@@ -66,7 +66,7 @@ public class OpenAiStreamingModel extends StreamingBaseModel {
     // if (safePrompt != null) {
     //   builder.safePrompt(safePrompt);
     // }
-    
+
     return builder.build();
   }
 

--- a/src/main/java/com/redhat/composer/config/retriever/contentretriever/ContentRetrieverClientFactory.java
+++ b/src/main/java/com/redhat/composer/config/retriever/contentretriever/ContentRetrieverClientFactory.java
@@ -22,20 +22,18 @@ public class ContentRetrieverClientFactory {
   @Inject
   ElasticsearchContentRetrieverClient elasticsearchContentRetrieverClient;
 
-  @ConfigProperty(name = "vector.store.type")
-  static String contentRetrieverType;
-
-  static final ContentRetrieverType DEFAULT_CONTENT_RETRIEVER = ContentRetrieverType.fromString(contentRetrieverType);
+  @ConfigProperty(name = "vector.store.default.type", defaultValue = "ELASTICSEARCH")
+  String defaultContentRetrieverType;
 
   /**
    * Get the Content Retriever Client.
-   * 
+   *
    * @param contentRetrieverType the ContentRetrieverType
    * @return the Content Retriever Client
    */
   public BaseContentRetrieverClient getContentRetrieverClient(ContentRetrieverType contentRetrieverType) {
     if (contentRetrieverType == null) {
-      contentRetrieverType = DEFAULT_CONTENT_RETRIEVER;
+      contentRetrieverType = ContentRetrieverType.fromString(defaultContentRetrieverType);;
     }
 
     switch (contentRetrieverType) {

--- a/src/main/java/com/redhat/composer/config/retriever/contentretriever/ContentRetrieverClientFactory.java
+++ b/src/main/java/com/redhat/composer/config/retriever/contentretriever/ContentRetrieverClientFactory.java
@@ -5,6 +5,8 @@ import com.redhat.composer.model.enums.ContentRetrieverType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 /**
  * Factory for Content Retriever Clients.
  */
@@ -13,17 +15,21 @@ public class ContentRetrieverClientFactory {
 
   @Inject
   WeaviateContentRetrieverClient weaviateEmbeddingStoreClient;
-  
+
   @Inject
   Neo4jContentRetrieverClient neo4jContentRetrieverClient;
 
   @Inject
   ElasticsearchContentRetrieverClient elasticsearchContentRetrieverClient;
-  
-  static final ContentRetrieverType DEFAULT_CONTENT_RETRIEVER = ContentRetrieverType.WEAVIATE;
+
+  @ConfigProperty(name = "vector.store.type")
+  static String contentRetrieverType;
+
+  static final ContentRetrieverType DEFAULT_CONTENT_RETRIEVER = ContentRetrieverType.fromString(contentRetrieverType);
 
   /**
    * Get the Content Retriever Client.
+   * 
    * @param contentRetrieverType the ContentRetrieverType
    * @return the Content Retriever Client
    */
@@ -31,17 +37,17 @@ public class ContentRetrieverClientFactory {
     if (contentRetrieverType == null) {
       contentRetrieverType = DEFAULT_CONTENT_RETRIEVER;
     }
-    
+
     switch (contentRetrieverType) {
-      case ContentRetrieverType.WEAVIATE:
+      case WEAVIATE:
         return weaviateEmbeddingStoreClient;
-      case ContentRetrieverType.NEO4J:
+      case NEO4J:
         return neo4jContentRetrieverClient;
-      case ContentRetrieverType.ELASTICSEARCH:
+      case ELASTICSEARCH:
         return elasticsearchContentRetrieverClient;
       default:
         throw new RuntimeException("Content Retriever type not found: " + contentRetrieverType);
     }
   }
-  
+
 }

--- a/src/main/java/com/redhat/composer/config/retriever/contentretriever/ElasticsearchContentRetrieverClient.java
+++ b/src/main/java/com/redhat/composer/config/retriever/contentretriever/ElasticsearchContentRetrieverClient.java
@@ -70,14 +70,14 @@ public class ElasticsearchContentRetrieverClient extends BaseContentRetrieverCli
           return httpClientBuilder;
         })
         .build();
-  
-    log.debug("Attempting to connect to Elasticsearch at " + host + " with index " + index);
+
+    log.info("Attempting to connect to Elasticsearch at " + host + " with index " + index);
 
     EmbeddingStore<TextSegment> store = ElasticsearchEmbeddingStore.builder()
                     .indexName(index)
                     .restClient(restClient)
                     .build();
-      
+
     // Retrieve the embedding model
     EmbeddingModel embeddingModel = getEmbeddingModel(request.getEmbeddingType());
 
@@ -86,7 +86,7 @@ public class ElasticsearchContentRetrieverClient extends BaseContentRetrieverCli
           .embeddingStore(store)
           .embeddingModel(embeddingModel)
         .build();
-      
+
     return contentRetriever;
   }
 

--- a/src/main/java/com/redhat/composer/model/request/retriever/ElasticsearchRequest.java
+++ b/src/main/java/com/redhat/composer/model/request/retriever/ElasticsearchRequest.java
@@ -23,7 +23,7 @@ public class ElasticsearchRequest extends BaseRetrieverRequest {
   String user;
 
   String password;
-  
+
 
   public ElasticsearchRequest() {
     contentRetrieverType = ContentRetrieverType.ELASTICSEARCH.getType();
@@ -112,7 +112,7 @@ public class ElasticsearchRequest extends BaseRetrieverRequest {
   }
 
   public ElasticsearchRequest password(String password) {
-    password(password);
+    setPassword(password);
     return this;
   }
   @Override
@@ -137,6 +137,6 @@ public class ElasticsearchRequest extends BaseRetrieverRequest {
       "}";
   }
 
-  
-  
+
+
 }

--- a/src/main/java/com/redhat/composer/util/mappers/MapperUtil.java
+++ b/src/main/java/com/redhat/composer/util/mappers/MapperUtil.java
@@ -34,31 +34,33 @@ public interface MapperUtil {
    * Maps a RetrieverRequest to a RetrieverConnectionEntity.
    */
   @Mappings({
-    @Mapping(target = "connectionEntity", source = "baseRetrieverRequest"),
-    @Mapping(target = "id", ignore = true)
+      @Mapping(target = "connectionEntity", source = "baseRetrieverRequest"),
+      @Mapping(target = "id", ignore = true)
   })
   RetrieverConnectionEntity toEntity(RetrieverRequest request);
 
   /**
    * Maps a LLMRequest to a LLMConnectionEntity.
+   * 
    * @param request the LLMRequest to map
    * @return the LLMConnectionEntity
    */
   @Mapping(target = "id", ignore = true)
   LlmConnectionEntity toEntity(LLMRequest request);
 
-
   /**
    * Maps a RetrieverConnectionEntity to a RetrieverRequest.
+   * 
    * @param entity the RetrieverConnectionEntity to map
    * @return the RetrieverRequest
    */
   @Mapping(source = "connectionEntity", target = "baseRetrieverRequest")
   @Mapping(target = "id", ignore = true)
   RetrieverRequest toRequest(RetrieverConnectionEntity entity);
-  
+
   /**
    * Maps a LLMConnectionEntity to a LLMRequest.
+   * 
    * @param entity the LLMConnectionEntity to map
    * @return the LLMRequest
    */
@@ -66,6 +68,7 @@ public interface MapperUtil {
 
   /**
    * Maps a BaseRetrieverRequest to a BaseRetrieverConnectionEntity.
+   * 
    * @param request the BaseRetrieverRequest to map
    * @return the BaseRetrieverConnectionEntity
    */
@@ -74,13 +77,13 @@ public interface MapperUtil {
     if (request == null) {
       return null;
     }
-    
+
     switch (ContentRetrieverType.fromString(request.getContentRetrieverType())) {
-      case ContentRetrieverType.WEAVIATE:
+      case WEAVIATE:
         return retrieverConnectionMapper.toEntity((WeaviateRequest) request);
-      case ContentRetrieverType.NEO4J:
+      case NEO4J:
         return retrieverConnectionMapper.toEntity((Neo4JRequest) request);
-      case ContentRetrieverType.ELASTICSEARCH:
+      case ELASTICSEARCH:
         return retrieverConnectionMapper.toEntity((ElasticsearchRequest) request);
       default:
         return null;
@@ -89,27 +92,26 @@ public interface MapperUtil {
 
   /**
    * Maps a BaseRetrieverConnectionEntity to a BaseRetrieverRequest.
-
+   * 
    * @param entity the BaseRetrieverConnectionEntity to map
    * @return the BaseRetrieverRequest
    */
   default BaseRetrieverRequest mapToBaseRequest(BaseRetrieverConnectionEntity entity) {
-    
+
     if (entity == null || entity.getContentRetrieverType() == null) {
       return null;
     }
 
     switch (entity.getContentRetrieverType()) {
-      case ContentRetrieverType.WEAVIATE:
+      case WEAVIATE:
         return retrieverConnectionMapper.toRequest((WeaviateConnectionEntity) entity);
-      case ContentRetrieverType.NEO4J:
+      case NEO4J:
         return retrieverConnectionMapper.toRequest((Neo4jEntity) entity);
-      case ContentRetrieverType.ELASTICSEARCH:
+      case ELASTICSEARCH:
         return retrieverConnectionMapper.toRequest((ElasticsearchConnectionEntity) entity);
       default:
         return null;
     }
   }
 
- 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ neo4j.default.password=<REPLACE_ME>
 # Default Elasticsearch
 ############################################################
 elasticsearch.default.host=http://elasticsearch-es-http:9200
-elasticsearch.default.index=docs_index
+elasticsearch.default.index=openshift_container_platform_en_us_4_17
 elasticsearch.default.user=elastic
 elasticsearch.default.password=<REPLACE_ME>
 
@@ -123,4 +123,4 @@ quarkus.keycloak.policy-enforcer.enable=true
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 
 # Select the vector store, defaults to ELASTICSEARCH
-vector.store.type=ELASTICSEARCH
+vector.store.default.type=ELASTICSEARCH

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,8 +20,8 @@ neo4j.default.password=<REPLACE_ME>
 ############################################################
 # Default Elasticsearch
 ############################################################
-elasticsearch.default.host=https://localhost
-elasticsearch.default.index=test_index
+elasticsearch.default.host=http://elasticsearch-es-http:9200
+elasticsearch.default.index=docs_index
 elasticsearch.default.user=elastic
 elasticsearch.default.password=<REPLACE_ME>
 
@@ -122,5 +122,5 @@ quarkus.keycloak.policy-enforcer.enable=true
 # This property is not effective when running the application in JVM or native modes
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 
-
-
+# Select the vector store, defaults to ELASTICSEARCH
+vector.store.type=ELASTICSEARCH

--- a/src/main/resources/db/changeLog.yml
+++ b/src/main/resources/db/changeLog.yml
@@ -26,7 +26,7 @@ databaseChangeLog:
         Please ensure that your responses are socially unbiased and positive in nature.
         If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct.
         If you don\'t know the answer to a question, please don\'t share false information.
-  # Create default assistants for weaviate
+  # Create default assistants for Elasticsearch
   - changeSet:
       id: 2
       author: quarkus
@@ -40,16 +40,16 @@ databaseChangeLog:
             collectionName: retriever_connection
         - insertOne:
             collectionName: retriever_connection
-            document: "{_id: ${rc.ocp.id}, name: 'ocp_4_17_default' , description: 'Openshift Container Platform Default Connection', 'connectionEntity': { '_t': 'weaviate', 'index': 'Openshift_container_platform_en_US_4_17'}}"
+            document: "{_id: ${rc.ocp.id}, name: 'ocp_4_17_default' , description: 'Openshift Container Platform Default Connection', 'connectionEntity': { '_t': 'Elasticsearch', 'index': 'openshift_container_platform_en_us_4_17'}}"
         - insertOne:
             collectionName: retriever_connection
-            document: "{_id: ${rc.rhel.id}, name: 'rhel_9_default' , description: 'Red Hat Enterprise Linux 9 Default Connection', 'connectionEntity': { '_t': 'weaviate', 'index': 'Red_hat_enterprise_linux_en_US_9'}}"
+            document: "{_id: ${rc.rhel.id}, name: 'rhel_9_default' , description: 'Red Hat Enterprise Linux 9 Default Connection', 'connectionEntity': { '_t': 'Elasticsearch', 'index': 'red_hat_enterprise_linux_en_us_9'}}"
         - insertOne:
             collectionName: retriever_connection
-            document: "{_id: ${rc.ansible.id}, name: 'ansible_2_5_default' , description: 'Ansible Automation Platform 2.5 Default Connection''connectionEntity': { '_t': 'weaviate', 'index': 'Red_hat_ansible_automation_platform_en_US_2_5'}}"
+            document: "{_id: ${rc.ansible.id}, name: 'ansible_2_5_default' , description: 'Ansible Automation Platform 2.5 Default Connection''connectionEntity': { '_t': 'Elasticsearch', 'index': 'red_hat_ansible_automation_platform_en_us_2_5'}}"
         - insertOne:
             collectionName: retriever_connection
-            document: "{_id: ${rc.rhoai.id}, name: 'rhoia_2_14_default' , description: 'Red Hat Openshift AI Self Managed 2.14 Default Connection''connectionEntity': { '_t': 'weaviate', 'index': 'Red_hat_openshift_ai_self_managed_en_US_2_14'}}"
+            document: "{_id: ${rc.rhoai.id}, name: 'rhoia_2_14_default' , description: 'Red Hat Openshift AI Self Managed 2.14 Default Connection''connectionEntity': { '_t': 'Elasticsearch', 'index': 'red_hat_openshift_ai_self_managed_en_us_2_14'}}"
 
         # Create LLM Connection collection
         - createCollection:
@@ -231,7 +231,7 @@ databaseChangeLog:
         #### **Email Drafting Guidelines**
 
         1. **Draft Structure**:
-          - **Subject Line**: 
+          - **Subject Line**:
             - Summarize the email\'s purpose in a clear and concise manner
             - Example: \"Follow-Up on Project Milestones\" or \"Request for Input on Upcoming Meeting Agenda.\"
           - **Opening**:


### PR DESCRIPTION
**Configuration Updates:**

- Updated elasticsearch.default.host to http://elasticsearch-es-http:9200 and elasticsearch.default.index to docs_index in application.properties.
- Added a new configuration property vector.store.type to specify the vector storage type (default: ELASTICSEARCH).


**Code Changes:**

- Replaced hardcoded default value for DEFAULT_CONTENT_RETRIEVER with a value retrieved from the vector.store.type configuration property.
- Updated switch case labels to use unqualified enum constants for cleaner syntax.